### PR TITLE
Confirmation should be true by default.

### DIFF
--- a/src/Commands/CDNifyCommand.php
+++ b/src/Commands/CDNifyCommand.php
@@ -153,7 +153,7 @@ class CDNifyCommand extends Command
 
         $this->info($job);
 
-        return $this->confirm('Do you wish to continue?');
+        return $this->confirm('Do you wish to continue?', true);
     }
     /**
      * Loads defaults from the config file.


### PR DESCRIPTION
while using --no-interactive mode, the whole process won't start, because the confirm method returns false by default.